### PR TITLE
Fix field-based storage test

### DIFF
--- a/benchmark/benchmark.gradle
+++ b/benchmark/benchmark.gradle
@@ -15,18 +15,20 @@ dependencies {
 }
 
 jmh {
-  timeUnit = 'us' // Output time unit. Available time units are: [m, s, ms, us, ns].
+  timeUnit = 'ns' // Output time unit. Available time units are: [m, s, ms, us, ns].
   benchmarkMode = ['avgt']
-  timeOnIteration = '10s'
-  iterations = 10 // Number of measurement iterations to do.
+  timeOnIteration = '1s'
+  iterations = 20 // Number of measurement iterations to do.
   fork = 1 // How many times to forks a single benchmark. Use 0 to disable forking altogether
 //  jvmArgs += ["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:StartFlightRecording=delay=5s,dumponexit=true,name=jmh-benchmark,filename=$rootDir/benchmark/build/reports/jmh/jmh-benchmark.jfr"]
 //  jvmArgs += ["-agentpath:$rootDir/benchmark/src/jmh/resources/libasyncProfiler.so=start,collapsed,file=$rootDir/benchmark/build/reports/jmh/profiler.txt"]
-  failOnError = true // Should JMH fail immediately if any benchmark had experienced the unrecoverable error?
-  warmup = '5s' // Time to spend at each warmup iteration.
+  failOnError = true
+  // Should JMH fail immediately if any benchmark had experienced the unrecoverable error?
+  warmup = '1s' // Time to spend at each warmup iteration.
 //  warmupBatchSize = 10 // Warmup batch size: number of benchmark method calls per operation.
-  warmupForks = 0 // How many warmup forks to make for a single benchmark. 0 to disable warmup forks.
-  warmupIterations = 1 // Number of warmup iterations to do.
+  warmupForks = 0
+  // How many warmup forks to make for a single benchmark. 0 to disable warmup forks.
+  warmupIterations = 20 // Number of warmup iterations to do.
 
 //  profilers = ['stack:lines=5;detailLine=true;period=5;excludePackages=true']
   // Use profilers to collect additional data. Supported profilers: [cl, comp, gc, stack, perf, perfnorm, perfasm, xperf, xperfasm, hs_cl, hs_comp, hs_gc, hs_rt, hs_thr]

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/storage/StorageBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/storage/StorageBenchmark.java
@@ -1,52 +1,50 @@
 package io.opentelemetry.benchmark.storage;
 
+import java.net.HttpURLConnection;
+import java.net.URI;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
 
 @Fork(
     jvmArgsAppend = {
-        "-javaagent:/Users/nsalnikovtarnovski/Documents/workspace/opentelemetry-auto-instr-java/opentelemetry-javaagent/build/libs/opentelemetry-javaagent-0.5.0-SNAPSHOT-all.jar",
-        "-Dota.exporter=logging",
-        "-XX:+UseParallelOldGC",
-        "-Xmx2g",
-        "-XX:+AlwaysPreTouch"
-//        "-Dio.opentelemetry.auto.slf4j.simpleLogger.defaultLogLevel=debug"
+      "-javaagent:C:/git/opentelemetry-java-instrumentation/opentelemetry-javaagent/build/libs/opentelemetry-javaagent-0.7.0-SNAPSHOT-all.jar",
+      "-Dota.exporter=logging"
     })
+@State(Scope.Thread)
 public class StorageBenchmark {
 
-  @Benchmark
-  public int noStorage() {
-    return noStorageInternal(0);
-  }
+  private HttpURLConnection httpURLConnection;
+  private String value;
 
-  private int noStorageInternal(int input){
-    if (input < 500) {
-      return noStorageInternal(input + 1);
-    }
-    return input;
+  @Setup
+  public void setup() throws Exception {
+    httpURLConnection = (HttpURLConnection) new URI("https://google.com").toURL().openConnection();
+    value = "abc";
   }
 
   @Benchmark
-  public int context() {
-    return contextInternal(0);
-  }
-
-  private int contextInternal(int input){
-    if (input < 500) {
-      return contextInternal(input + 1);
-    }
-    return input;
+  public String noStorage() {
+    return value;
   }
 
   @Benchmark
-  public int field() {
-    return fieldInternal(0);
+  public String contextStorage() {
+    return contextStorageInstrumented(value);
   }
 
-  private int fieldInternal(int input){
-    if (input < 500) {
-      return fieldInternal(input + 1);
-    }
-    return input;
+  private String contextStorageInstrumented(String value) {
+    return value;
+  }
+
+  @Benchmark
+  public String fieldStorage() {
+    return fieldStorageInstrumented(httpURLConnection, value);
+  }
+
+  private String fieldStorageInstrumented(HttpURLConnection httpURLConnection, String value) {
+    return value;
   }
 }

--- a/instrumentation/storage-test/src/main/java/io/opentelemetry/instrumentation/storage/StorageDecorator.java
+++ b/instrumentation/storage-test/src/main/java/io/opentelemetry/instrumentation/storage/StorageDecorator.java
@@ -17,23 +17,18 @@
 package io.opentelemetry.instrumentation.storage;
 
 import io.grpc.Context;
-import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
-import io.opentelemetry.trace.Tracer;
 
 public class StorageDecorator extends BaseDecorator {
   public static final StorageDecorator DECORATE = new StorageDecorator();
-  public static final Tracer TRACER =
-      OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.storage");
 
-  static final Context.Key<Integer> CONTEXT_CLIENT_SPAN_KEY =
-      Context.key("some-key");
+  static final Context.Key<String> CONTEXT_CLIENT_SPAN_KEY = Context.key("some-key");
 
-  public Context attach(int value){
-    return Context.current().withValue(CONTEXT_CLIENT_SPAN_KEY, value + 1);
+  public Context attach(String value) {
+    return Context.current().withValue(CONTEXT_CLIENT_SPAN_KEY, value);
   }
 
-  public int getValue(Context context){
+  public String getValue(Context context) {
     return CONTEXT_CLIENT_SPAN_KEY.get(context);
   }
 }

--- a/instrumentation/storage-test/src/main/java/io/opentelemetry/instrumentation/storage/StorageInstrumenter.java
+++ b/instrumentation/storage-test/src/main/java/io/opentelemetry/instrumentation/storage/StorageInstrumenter.java
@@ -1,23 +1,23 @@
 package io.opentelemetry.instrumentation.storage;
 
+import static io.opentelemetry.context.ContextUtils.withScopedContext;
+import static io.opentelemetry.instrumentation.storage.StorageDecorator.DECORATE;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
 import com.google.auto.service.AutoService;
 import io.opentelemetry.auto.bootstrap.InstrumentationContext;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.auto.tooling.Instrumenter.Default;
 import io.opentelemetry.context.Scope;
+import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.Argument;
-import net.bytebuddy.asm.Advice.Origin;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-
-import static io.opentelemetry.context.ContextUtils.withScopedContext;
-import static io.opentelemetry.instrumentation.storage.StorageDecorator.DECORATE;
-import static java.util.Collections.singletonMap;
-import static net.bytebuddy.matcher.ElementMatchers.named;
 
 @AutoService(Instrumenter.class)
 public class StorageInstrumenter extends Default {
@@ -34,32 +34,26 @@ public class StorageInstrumenter extends Default {
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     Map result = new HashMap();
-    result.put(named("contextInternal"), getClass().getName() + "$GrpcContextAdvice");
-    result.put(named("fieldInternal"), getClass().getName() + "$FieldAdvice");
+    result.put(named("contextStorageInstrumented"), getClass().getName() + "$ContextStorageAdvice");
+    result.put(named("fieldStorageInstrumented"), getClass().getName() + "$FieldStorageAdvice");
     return result;
   }
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {
-        packageName + ".StorageDecorator",
-        packageName + ".StorageKey",
-    };
+    return new String[] {packageName + ".StorageDecorator"};
   }
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap("io.opentelemetry.instrumentation.storage.StorageKey", Integer.class.getName());
+    return singletonMap("java.net.HttpURLConnection", String.class.getName());
   }
 
-  public static class GrpcContextAdvice {
+  public static class ContextStorageAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope start(
-        @Origin("#m") final String method,
-        @Argument(0) final int value) {
-
-      return withScopedContext(DECORATE.attach(value + 1));
+    public static Scope start(final @Argument(0) String value) {
+      return withScopedContext(DECORATE.attach(value));
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -68,21 +62,14 @@ public class StorageInstrumenter extends Default {
     }
   }
 
-  public static class FieldAdvice {
+  public static class FieldStorageAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope start(
-        @Origin("#m") final String method,
-        @Argument(0) final int value) {
+    public static void start(
+        @Argument(0) final HttpURLConnection httpURLConnection, final @Argument(1) String value) {
 
-      InstrumentationContext.get(StorageKey.class, Integer.class).put(StorageKey.INSTANCE, value + 1);
-
-      return withScopedContext(DECORATE.attach(value + 1));
-    }
-
-    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void stop(@Advice.Enter final Scope scope) {
-      scope.close();
+      InstrumentationContext.get(HttpURLConnection.class, String.class)
+          .put(httpURLConnection, value);
     }
   }
 }

--- a/instrumentation/storage-test/src/main/java/io/opentelemetry/instrumentation/storage/StorageKey.java
+++ b/instrumentation/storage-test/src/main/java/io/opentelemetry/instrumentation/storage/StorageKey.java
@@ -1,5 +1,0 @@
-package io.opentelemetry.instrumentation.storage;
-
-public class StorageKey {
-  public static final StorageKey INSTANCE = new StorageKey();
-}


### PR DESCRIPTION
The issue was that `StorageKey`, which was being used as the `InstrumentationContext` key, was part of the instrumentation itself, and so it wasn't being instrumented itself, and so the field was not being added to it, and so `InstrumentationContext` was falling back to a map.

New numbers:

```
Benchmark                                                     Mode  Cnt     Score     Error   Units
StorageBenchmark.contextStorage                               avgt   20    26.768 ±   0.331   ns/op
StorageBenchmark.contextStorage:·gc.alloc.rate                avgt   20  2089.803 ±  25.111  MB/sec
StorageBenchmark.contextStorage:·gc.alloc.rate.norm           avgt   20    88.000 ±   0.001    B/op
StorageBenchmark.fieldStorage                                 avgt   20     3.174 ±   0.045   ns/op
StorageBenchmark.fieldStorage:·gc.alloc.rate                  avgt   20     0.004 ±   0.001  MB/sec
StorageBenchmark.fieldStorage:·gc.alloc.rate.norm             avgt   20    ? 10??              B/op
StorageBenchmark.noStorage                                    avgt   20     3.838 ±   0.075   ns/op
StorageBenchmark.noStorage:·gc.alloc.rate                     avgt   20     0.004 ±   0.001  MB/sec
StorageBenchmark.noStorage:·gc.alloc.rate.norm                avgt   20    ? 10??              B/op
```